### PR TITLE
cleans up jumbotron

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,7 @@
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
-  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "assets/main.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ "/feed.xml" | relative_url }}">
 

--- a/_layouts/about-pages.html
+++ b/_layouts/about-pages.html
@@ -4,10 +4,6 @@ layout: default
 <div class="jumbotron jumbotron-fluid pb-0 pt-5">
   <div class="container text-center">
     <h1 class="display-3 highlight-text">{{ page.title | escape }}</h1>
-    <!-- <p class="lead">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </p>
-    <p class="lead">Sed sit amet aliquam mi. Vestibulum in massa non dolor sollicitudin suscipit. Nam a lacus orci. Duis.
-    </p> -->
     <ul class="nav custom-nav justify-content-center pt-4">
       <li class="nav-item">
         <a class="nav-link" href="{{ site.baseurl }}/mission/">Mission/Vision</a>

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -1,0 +1,18 @@
+---
+layout: default
+---
+<div class="jumbotron jumbotron-fluid">
+  <div class="container text-center">
+    <h1 class="display-3 highlight-text">{{ page.title | escape }}</h1>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <p>
+        {{ content }}
+      </p>
+    </div>
+  </div>
+</div>

--- a/_layouts/get-involved-pages.html
+++ b/_layouts/get-involved-pages.html
@@ -4,16 +4,18 @@ layout: default
 <div class="jumbotron jumbotron-fluid">
   <div class="container text-center">
     <h1 class="display-3 highlight-text">{{ page.title | escape }}</h1>
-      <p class="lead">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </p>
-    <p class="lead">Sed sit amet aliquam mi. Vestibulum in massa non dolor sollicitudin suscipit. Nam a lacus orci. Duis.
-    </p>
     <ul class="nav custom-nav justify-content-center">
       <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl }}/mission/">Mission/Vision</a>
+        <a class="nav-link" href="{{ site.baseurl }}/volunteering/">Volunteering</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl }}/altgeld-sawyer/">Altgeld Sawyer</a>
+        <a class="nav-link" href="{{ site.baseurl }}/compost/">Compost</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="{{ site.baseurl }}/public-events/">Public Events</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="{{ site.baseurl }}/partnerships/">Partnerships</a>
       </li>
     </ul>
   </div>

--- a/_layouts/resources-pages.html
+++ b/_layouts/resources-pages.html
@@ -4,16 +4,12 @@ layout: default
 <div class="jumbotron jumbotron-fluid">
   <div class="container text-center">
     <h1 class="display-3 highlight-text">{{ page.title | escape }}</h1>
-      <p class="lead">Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    </p>
-    <p class="lead">Sed sit amet aliquam mi. Vestibulum in massa non dolor sollicitudin suscipit. Nam a lacus orci. Duis.
-    </p>
     <ul class="nav custom-nav justify-content-center">
       <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl }}/mission/">Mission/Vision</a>
+        <a class="nav-link" href="{{ site.baseurl }}/cfc-volunteers/">CFC Volunteers</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="{{ site.baseurl }}/altgeld-sawyer/">Altgeld Sawyer</a>
+        <a class="nav-link" href="{{ site.baseurl }}/general-farming/">General Farming</a>
       </li>
     </ul>
   </div>
@@ -27,4 +23,4 @@ layout: default
       </p>
     </div>
   </div>
-</div> s
+</div> 

--- a/calendar.md
+++ b/calendar.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: calendar
 title: Calendar
 permalink: /calendar/
 ---


### PR DESCRIPTION
This gets rid of the extra text in the jumbotron. It also fixes the jumbotron navigation I accidentally turned to all be the same as about-pages in my last merge. And an update that should fix CSS on the life site. 